### PR TITLE
Fix env variable usage in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     needs: lint
     services:
       postgres:
-        image: "postgres:${{ env.POSTGRES_VERSION }}"
+        image: postgres:${{ env.POSTGRES_VERSION }}
         env:
           POSTGRES_USER: btcstack
           POSTGRES_PASSWORD: testpassword
@@ -75,7 +75,7 @@ jobs:
           --health-retries 5
       
       redis:
-        image: "redis:${{ env.REDIS_VERSION }}"
+        image: redis:${{ env.REDIS_VERSION }}
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,9 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     needs: lint
-    env:
-      POSTGRES_VERSION: ${{ env.POSTGRES_VERSION }}
-      REDIS_VERSION: ${{ env.REDIS_VERSION }}
     services:
       postgres:
-        image: postgres:${{ env.POSTGRES_VERSION }}
+        image: "postgres:${{ env.POSTGRES_VERSION }}"
         env:
           POSTGRES_USER: btcstack
           POSTGRES_PASSWORD: testpassword
@@ -78,7 +75,7 @@ jobs:
           --health-retries 5
       
       redis:
-        image: redis:${{ env.REDIS_VERSION }}
+        image: "redis:${{ env.REDIS_VERSION }}"
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   PYTHON_VERSION: '3.13'
-  POSTGRES_VERSION: '15-alpine'
-  REDIS_VERSION: '7-alpine'
 
 jobs:
   lint:
@@ -61,7 +59,7 @@ jobs:
     needs: lint
     services:
       postgres:
-        image: postgres:${{ env.POSTGRES_VERSION }}
+        image: postgres:15-alpine
         env:
           POSTGRES_USER: btcstack
           POSTGRES_PASSWORD: testpassword
@@ -75,7 +73,7 @@ jobs:
           --health-retries 5
       
       redis:
-        image: redis:${{ env.REDIS_VERSION }}
+        image: redis:7-alpine
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,12 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     needs: lint
+    env:
+      POSTGRES_VERSION: ${{ env.POSTGRES_VERSION }}
+      REDIS_VERSION: ${{ env.REDIS_VERSION }}
     services:
       postgres:
-        image: "postgres:${{ env.POSTGRES_VERSION }}"
+        image: postgres:${{ env.POSTGRES_VERSION }}
         env:
           POSTGRES_USER: btcstack
           POSTGRES_PASSWORD: testpassword
@@ -75,7 +78,7 @@ jobs:
           --health-retries 5
       
       redis:
-        image: "redis:${{ env.REDIS_VERSION }}"
+        image: redis:${{ env.REDIS_VERSION }}
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     needs: lint
     services:
       postgres:
-        image: postgres:${{ env.POSTGRES_VERSION }}
+        image: "postgres:${{ env.POSTGRES_VERSION }}"
         env:
           POSTGRES_USER: btcstack
           POSTGRES_PASSWORD: testpassword
@@ -75,7 +75,7 @@ jobs:
           --health-retries 5
       
       redis:
-        image: redis:${{ env.REDIS_VERSION }}
+        image: "redis:${{ env.REDIS_VERSION }}"
         ports:
           - 6379:6379
         options: >-


### PR DESCRIPTION
## Summary
- quote service image names so env vars parse correctly in GitHub Actions

## Testing
- `pytest -q` *(fails: unrecognized arguments --cov=btc_stack_builder --cov-report=term-missing)*

------
https://chatgpt.com/codex/tasks/task_e_684465a218d88320a08cc86415f77aca