### PR TITLE
Ensure Safety SARIF file exists

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -59,9 +59,12 @@ jobs:
       
       - name: Scan dependencies with Safety
         run: |
-          cd $GITHUB_WORKSPACE
+          cd "$GITHUB_WORKSPACE"
           safety check -r requirements.txt --sarif -o safety-results.sarif || true
-          ls -la
+          if [ ! -f safety-results.sarif ]; then
+            echo '{"version":"2.1.0","runs":[]}' > safety-results.sarif
+          fi
+          ls -la safety-results.sarif
       
       - name: Upload Safety results
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
## Summary
- ensure `safety-results.sarif` exists before uploading

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog')*

------
https://chatgpt.com/codex/tasks/task_e_684493acf1a883209c3d145694c35af9