### PR TITLE
Fix: Exclude build directory from mypy checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ warn_unused_configs = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 ignore_errors = true
+exclude = ["build/"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
Mypy was reporting a "Duplicate module named 'btc_stack_builder'" error because it was checking both the source directory and the build directory.

This commit updates the mypy configuration in `pyproject.toml` to exclude the `build/` directory, resolving the error.